### PR TITLE
Avoid hardcoded languages in Settings

### DIFF
--- a/app/TypiCMS/Modules/Settings/Views/settings/admin/_form.blade.php
+++ b/app/TypiCMS/Modules/Settings/Views/settings/admin/_form.blade.php
@@ -48,7 +48,7 @@
 </div>
 <div class="form-group @if($errors->has('adminLocale'))has-error@endif">
     {{ Form::label('adminLocale', trans('validation.attributes.adminLocale'), array('class' => 'control-label')) }}
-    {{ Form::select('adminLocale', array('en' => 'English', 'fr' => 'French'), null, array('class' => 'form-control')) }}
+    {{ Form::select('adminLocale', Lang::get('global.languages'), null, array('class' => 'form-control')) }}
     @if($errors->has('adminLocale'))
     <span class="help-block">{{ $errors->first('adminLocale') }}</span>
     @endif


### PR DESCRIPTION
I've noticed a hardcoded array of admin languages in the Settings module view.
As an enhancement it would be great the ability of adding locales dynamically in CMS administration panel and fill keys for a new locale in Translation module. And of course keeping all current translations will help to build great multilingual CMS without editing whole bunch of lang files.
