### PR TITLE
Regenerate IDE helper on every composer update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
 			"php artisan clear-compiled"
 		],
 		"post-update-cmd": [
-			"php artisan optimize"
+			"php artisan optimize",
+			"php artisan ide-helper:generate"
 		],
 		"post-create-project-cmd": [
 			"php artisan key:generate"


### PR DESCRIPTION
It is necessary to rerun `php artisan ide-helper:generate` after every composer update to keep changes in files up-to-date.
